### PR TITLE
Use local import path for mime/quotedprintable

### DIFF
--- a/multipart/multipart.go
+++ b/multipart/multipart.go
@@ -19,8 +19,9 @@ import (
 	"io"
 	"io/ioutil"
 	"mime"
-	"mime/quotedprintable"
 	"net/textproto"
+	
+	"github.com/sthulb/mime/quotedprintable"
 )
 
 var emptyParams = make(map[string]string)


### PR DESCRIPTION
This allows this package to build on Go 1.4.2 as well as 1.5 (which is nice for Terraform development as the Go 1.5 compiler is slow!)